### PR TITLE
Fix icon theming issues.

### DIFF
--- a/refresh-wifi@kgshank.net/extension.js
+++ b/refresh-wifi@kgshank.net/extension.js
@@ -38,7 +38,8 @@ function _buildLayoutLocal() {
                                        track_hover: true,
                                        accessible_name: _("Refresh Connections"),
                                        style_class: 'system-menu-action' });
-    refreshButton.child = new St.Icon({ icon_name: "view-refresh-symbolic" });
+    refreshButton.add_style_class_name('refresh-wifi-button');
+    refreshButton.child = new St.Icon({ icon_name: 'view-refresh-symbolic', style_class: 'nm-dialog-icon' });
     refreshButton.connect('clicked', Lang.bind(this, function(){
                     let accessPoints = this._device.get_access_points() || [ ];
                     accessPoints.forEach(Lang.bind(this, function(ap) {

--- a/refresh-wifi@kgshank.net/stylesheet.css
+++ b/refresh-wifi@kgshank.net/stylesheet.css
@@ -1,0 +1,3 @@
+.refresh-wifi-button {
+    color: inherit;
+}


### PR DESCRIPTION
Thank you so much for making this extension!

This PR fixes an issue with the refresh icon. In this extension a CSS class for a menu icon is used in a dialog. Many themes have light dialogs and dark menus. What then happens under many 3rd party themes is a white icon on a white background. I have included screenshots to illustrate this. This PR adds the style class for the network manager dialog icons to the St.Icon so that it is the correct color. It also adds a CSS class to force the button to inherit the correct coloring.

# Example of a theme with dark menus:

![dark menu example](http://i.imgur.com/aDDdj1i.png)

# Before PR:

![before changes](http://i.imgur.com/IQdL0oh.png)

# After PR:

![before changes](http://i.imgur.com/avqggnJ.png)